### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/server/app/assets/javascripts/api_docs.ts
+++ b/server/app/assets/javascripts/api_docs.ts
@@ -18,10 +18,10 @@ class ApiDocs {
       const slugDropdown = document.getElementById(
         'select-slug',
       ) as HTMLSelectElement
-      const slugValue: string = slugDropdown.value
+      const slugValue: string = encodeURIComponent(slugDropdown.value)
 
       const versionDropdown = event.currentTarget as HTMLSelectElement
-      const versionValue: string = versionDropdown.value
+      const versionValue: string = encodeURIComponent(versionDropdown.value)
 
       window.location.href = `/api/docs/v1/${slugValue}/${versionValue}`
     })


### PR DESCRIPTION
Potential fix for [https://github.com/Shivam7-1/civiform/security/code-scanning/1](https://github.com/Shivam7-1/civiform/security/code-scanning/1)

To fix the problem, we need to ensure that the values derived from the user input are properly encoded before being used in the URL. This can be achieved by using `encodeURIComponent` to encode the `slugValue` and `versionValue` before constructing the URL. This will prevent any malicious characters from being interpreted as part of the URL.

- Modify the code in `server/app/assets/javascripts/api_docs.ts` to use `encodeURIComponent` for `slugValue` and `versionValue`.
- No additional imports are needed as `encodeURIComponent` is a built-in JavaScript function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
